### PR TITLE
Update main.nf

### DIFF
--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -22,14 +22,14 @@ process BWA_INDEX {
     path fasta
 
     output:
-    path "bwa"          , emit: index
+    path "index"          , emit: index
     path "*.version.txt", emit: version
 
     script:
     def software = getSoftwareName(task.process)
     """
-    mkdir bwa
-    bwa index $options.args $fasta -p bwa/${fasta.baseName}
+    mkdir index
+    bwa index $options.args -p index/${fasta.baseName} $fasta 
     echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//' > ${software}.version.txt
     """
 }


### PR DESCRIPTION
## PR checklist
* The argument `-p bwa/${${fasta.baseName}` doesn't make the indicies in the `bwa` dir unless it comes before the fasta sequence
* If these are made in a directory called index then the publishDir will become `bwa/index`
- [x] This comment contains a description of changes (with reason).

